### PR TITLE
Fixed default user and group ID resolving, using SQL values

### DIFF
--- a/templates/users.d/users.conf.erb
+++ b/templates/users.d/users.conf.erb
@@ -15,8 +15,9 @@ SQLAuthTypes                    Crypt Backend OpenSSL
 SQLAuthenticate                 users
 SQLConnectInfo                  <%= @mysql_db %>@<%= @mysql_host %>:3306 <%= @mysql_user %> <%= @mysql_pass %>
 SQLUserInfo                     ftp_users userid passwd uid gid home shell
-SQLDefaultUID                   5001
-SQLDefaultGID                   5001
+SQLGroupInfo                    ftp_group groupname gid members
+SQLMinUserUID                   101
+SQLMinUserGID                   65534
 SQLUserWhereClause  "active = 'Y' AND deleted = 'N' AND <%= @protocol %> = 'true'"
 <%- if @protocol == 'sftp' -%>
 SQLNamedQuery get-user-authorized-keys SELECT "sshkey FROM sftp_userkeys WHERE name='%U'"

--- a/templates/users.d/users.conf.erb
+++ b/templates/users.d/users.conf.erb
@@ -17,7 +17,7 @@ SQLConnectInfo                  <%= @mysql_db %>@<%= @mysql_host %>:3306 <%= @my
 SQLUserInfo                     ftp_users userid passwd uid gid home shell
 SQLGroupInfo                    ftp_group groupname gid members
 SQLMinUserUID                   101
-SQLMinUserGID                   65534
+SQLMinUserGID                   101
 SQLUserWhereClause  "active = 'Y' AND deleted = 'N' AND <%= @protocol %> = 'true'"
 <%- if @protocol == 'sftp' -%>
 SQLNamedQuery get-user-authorized-keys SELECT "sshkey FROM sftp_userkeys WHERE name='%U'"


### PR DESCRIPTION
Fixed default user and group ID resolving, using SQL valuesfixed value of 5001, which is the local system 'proftpd' user
# Important
## SQL
### Check if the ftp_users table uid and gid match your filesystem uid and gid; eitherways update your DB content or update your filesystem
```UPDATE `ftp_users` SET (`uid`, `gid`) VALUES ('5001','5001');```
### Check if the ftp_group table contains a default gid; this should match the gid you assigned your users in ftp_users
```INSERT INTO `ftp_group` (`groupname`, `gid`, `members`) VALUES ('ftpuser', 5001, 'proftpd');```