### PR TITLE
sFTP key based authentication when file based backend is enabled

### DIFF
--- a/templates/users.d/users.conf.erb
+++ b/templates/users.d/users.conf.erb
@@ -6,6 +6,9 @@ RequireValidShell       off
 AuthOrder mod_auth_file.c
 AuthUserFile            /etc/proftpd/users.d/<%= @vhost_name %>.passwd
 AuthGroupFile           /etc/proftpd/users.d/<%= @vhost_name %>.group
+<%- if @protocol == 'sftp' -%>
+SFTPAuthorizedUserKeys file:~/.ssh/authorized_keys
+<%- end -%>
 <%- end -%>
 
 <%- if @authentication == 'sql' -%>


### PR DESCRIPTION
If the sFTP protocol is used and file based backend is enabled,
key authentication may be done by putting an RFC4716 formatted key to the user's homefolder, under: ~/.ssh/authorized_keys

Key formatting README: https://tools.ietf.org/html/rfc4716

*Important note*: 
```
The Header-tag MUST NOT be more than 64 8-bit bytes and is case-
insensitive.  The Header-value MUST NOT be more than 1024 8-bit
bytes.  Each line in the header MUST NOT be more than 72 8-bit bytes.
A line is continued if the last character in the line is a '\'.
```
REF: https://tools.ietf.org/html/rfc4716#section-3.3 
Otherwise you'll get errors like this in your sftp logfile:
```
public key fingerprint: f6:0c:64:5d:bb:62:f5:b4:d6:8c:5b:eb:44:96:de:de
line too long (74) on line 1 of '/home/user/.ssh/authorized_keys'
Make sure that '/home/user/.ssh/authorized_keys' is a RFC4716 formatted key
error base64-decoding key data in '/home/user/.ssh/authorized_keys'
error comparing keys from '/home/user/.ssh/authorized_keys': Invalid argument
```
ssh-keygen has the habit it writing a long NON-RFC4716 compliant Comment header:
```
Comment: "2048-bit RSA, converted from OpenSSH by user@machine.earth.local"
```
which actually should be:
```
Comment: "2048-bit RSA, converted from OpenSSH by user@machine.earth\
.local"
```
REF: https://bugzilla.mindrot.org/show_bug.cgi?id=1630