### PR TITLE
Fixes #36 - fixing file permissions and lint issues with sftp

### DIFF
--- a/manifests/instance/sftp.pp
+++ b/manifests/instance/sftp.pp
@@ -6,7 +6,7 @@ define proftpd::instance::sftp(
   $server_name='sFTP server',
   $server_ident='sFTP server ready',
   $server_admin='root@server',
-  $logdir=undef,
+  $logdir='/var/log',
   $max_clients='45',
   $max_loginattempts='3',
   $default_root='~',
@@ -46,8 +46,9 @@ define proftpd::instance::sftp(
   if ! defined(File["${logdir}/proftpd"]) {
     file { "${logdir}/proftpd":
       ensure => directory,
-      owner  => 'proftpd',
-      group  => 'proftpd',
+      owner  => $proftpd::proftpd_user,
+      group  => $proftpd::proftpd_group,
+      mode   => '0750',
     }
 
   }
@@ -55,8 +56,9 @@ define proftpd::instance::sftp(
   if ! defined(File["${logdir}/proftpd/sftp"]) {
     file { "${logdir}/proftpd/sftp":
       ensure  => directory,
-      owner   => 'proftpd',
-      group   => 'proftpd',
+      owner   => $proftpd::proftpd_user,
+      group   => $proftpd::proftpd_group,
+      mode    => '0750',
       require => File["${logdir}/proftpd"],
       notify  => Class['proftpd::service']
     }
@@ -64,7 +66,7 @@ define proftpd::instance::sftp(
 
   file { "/etc/proftpd/sites.d/${vhost_name}.conf":
     ensure  => file,
-    owner   => root,
+    owner   => 'root',
     group   => $proftpd::proftpd_group,
     mode    => '0640',
     content => template("${module_name}/sites.d/sftp.conf.erb"),
@@ -73,7 +75,7 @@ define proftpd::instance::sftp(
 
   file { "/etc/proftpd/users.d/${vhost_name}.conf":
     ensure  => file,
-    owner   => root,
+    owner   => 'root',
     group   => $proftpd::proftpd_group,
     mode    => '0640',
     content => template("${module_name}/users.d/users.conf.erb"),
@@ -83,7 +85,7 @@ define proftpd::instance::sftp(
   if $authentication == 'file' {
     file { "/etc/proftpd/users.d/${vhost_name}.passwd":
       ensure  => file,
-      owner   => root,
+      owner   => 'root',
       group   => $proftpd::proftpd_group,
       mode    => '0640',
       replace => false
@@ -91,7 +93,7 @@ define proftpd::instance::sftp(
 
     file { "/etc/proftpd/users.d/${vhost_name}.group":
       ensure  => file,
-      owner   => root,
+      owner   => 'root',
       group   => $proftpd::proftpd_group,
       mode    => '0640',
       replace => false

--- a/manifests/instance/sftp.pp
+++ b/manifests/instance/sftp.pp
@@ -1,3 +1,4 @@
+# Type: proftpd::instance::sftp - creates an SFTP server instance
 define proftpd::instance::sftp(
   $ensure=present,
   $ipaddress='0.0.0.0',
@@ -44,10 +45,11 @@ define proftpd::instance::sftp(
 
   if ! defined(File["${logdir}/proftpd"]) {
     file { "${logdir}/proftpd":
-      ensure  => directory,
-      owner   => 'proftpd',
-      group   => 'proftpd',
+      ensure => directory,
+      owner  => 'proftpd',
+      group  => 'proftpd',
     }
+
   }
 
   if ! defined(File["${logdir}/proftpd/sftp"]) {
@@ -63,8 +65,8 @@ define proftpd::instance::sftp(
   file { "/etc/proftpd/sites.d/${vhost_name}.conf":
     ensure  => file,
     owner   => root,
-    group   => root,
-    mode    => '0644',
+    group   => $proftpd::proftpd_group,
+    mode    => '0640',
     content => template("${module_name}/sites.d/sftp.conf.erb"),
     notify  => Class['proftpd::service']
   }
@@ -72,8 +74,8 @@ define proftpd::instance::sftp(
   file { "/etc/proftpd/users.d/${vhost_name}.conf":
     ensure  => file,
     owner   => root,
-    group   => root,
-    mode    => '0644',
+    group   => $proftpd::proftpd_group,
+    mode    => '0640',
     content => template("${module_name}/users.d/users.conf.erb"),
     notify  => Class['proftpd::service']
   }
@@ -82,16 +84,16 @@ define proftpd::instance::sftp(
     file { "/etc/proftpd/users.d/${vhost_name}.passwd":
       ensure  => file,
       owner   => root,
-      group   => root,
-      mode    => '0644',
+      group   => $proftpd::proftpd_group,
+      mode    => '0640',
       replace => false
     }
 
     file { "/etc/proftpd/users.d/${vhost_name}.group":
       ensure  => file,
       owner   => root,
-      group   => root,
-      mode    => '0644',
+      group   => $proftpd::proftpd_group,
+      mode    => '0640',
       replace => false
     }
   }


### PR DESCRIPTION
This fixes the permissions on the passwd file and some others. The passwd file permissions were preventing proftpd from starting on CentOS 7.